### PR TITLE
Fix currentPath for arrays of nested documents

### DIFF
--- a/lib/schema.js
+++ b/lib/schema.js
@@ -194,7 +194,7 @@ function buildFieldsFromSchema(fields) {
       // and https://www.elastic.co/guide/en/elasticsearch/guide/current/nested-objects.html
       if (_.isPlainObject(value[0])) {
         Object.keys(value[0]).forEach(function (v) {
-          mapSchemaType(v, key);
+          mapSchemaType(v, key + '[0]');
         });
       } else {
         schemaType = findType(value[0]);
@@ -212,6 +212,7 @@ function buildFieldsFromSchema(fields) {
         options: typeOptions
       };
 
+      currentPath = currentPath.replace('[0]', '')
       dot.str(currentPath, fieldObj, results.fields);
     }
   }


### PR DESCRIPTION
The current version does have a bug with arrays of nested documents due to the `dot.pick` lookup on arrays on line 155 of schema.js.